### PR TITLE
fix(reusable): address copilot feedback on pr-url path

### DIFF
--- a/.github/workflows/flake-review-reusable.yml
+++ b/.github/workflows/flake-review-reusable.yml
@@ -76,7 +76,7 @@ jobs:
           PR_URL: ${{ inputs.pr-url }}
         run: |
           if [ -z "$PR_URL" ]; then
-            echo "pr-url input is empty and no pull_request event context is available."
+            echo "::error::pr-url input is empty and no pull_request event context is available." >&2
             exit 1
           fi
           pkg_args=()
@@ -120,13 +120,21 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           PR_URL: ${{ inputs.pr-url }}
         run: |
+          if [ -z "$PR_URL" ]; then
+            echo "::error::pr-url input is empty and no pull_request event context is available." >&2
+            exit 1
+          fi
+          if [[ ! "$PR_URL" =~ /pull/([0-9]+)(/|$|[?#]) ]]; then
+            echo "::error::pr-url does not look like a GitHub PR URL: $PR_URL" >&2
+            exit 1
+          fi
+          PR_NUMBER="${BASH_REMATCH[1]}"
           shopt -s nullglob
           json_files=(reports/*/*.json)
           if [ "${#json_files[@]}" -eq 0 ]; then
             echo "No report files found - no packages changed across all platforms."
             exit 0
           fi
-          PR_NUMBER="${PR_URL##*/}"
           flake-review merge-reports \
             "${json_files[@]}" \
             --title "Flake Review Results for [#${PR_NUMBER}](${PR_URL})" \

--- a/.github/workflows/flake-review.yml
+++ b/.github/workflows/flake-review.yml
@@ -25,5 +25,5 @@ jobs:
     uses: ./.github/workflows/flake-review-reusable.yml
     with:
       install-from-checkout: true
-      concurrency-group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+      concurrency-group: ${{ github.workflow }}-${{ github.event.pull_request.number || inputs.pr-url || github.ref }}
       pr-url: ${{ inputs.pr-url || github.event.pull_request.html_url }}


### PR DESCRIPTION
Follow-up to #16. Addresses the actionable Copilot review comments:

- **Robust PR number parsing** — `${PR_URL##*/}` broke on URLs ending in `/`, `?diff=split`, `/files`, or `#anchor`. Replaced with a regex that extracts the digits after `/pull/`.
- **Validate `pr-url` in `post-results`** — the review step's early exit doesn't prevent `post-results` from running (`if: always()`), so an empty URL would still try to post a malformed title. Added the same guard.
- **`::error` annotations** — error messages now show up as GitHub Actions annotations and go to stderr.
- **Concurrency group includes `pr-url`** — two `workflow_dispatch` runs from the same branch against different PRs would have cancelled each other; pr-url now participates in the group key.

Skipping the Copilot suggestion to flip `install-from-checkout` for `workflow_dispatch` — the intent of the self-test caller is to exercise the reusable workflow as it sits on the checked-out ref, which is what the current behaviour does.